### PR TITLE
Upgrade axios dependency from 1.2.0 to 1.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "agentkeepalive": "^4.2.1",
-        "axios": "^1.1.3",
+        "axios": "^1.4.0",
         "hpagent": "^1.1.0",
         "tough-cookie": "^4.1.2"
       },
@@ -614,9 +614,9 @@
       "dev": true
     },
     "node_modules/axios": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.2.0.tgz",
-      "integrity": "sha512-zT7wZyNYu3N5Bu0wuZ6QccIf93Qk1eV8LOewxgjOZFd2DenOs98cJ7+Y6703d0wkaXGY6/nZd4EweJaHz9uzQw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.4.0.tgz",
+      "integrity": "sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==",
       "dependencies": {
         "follow-redirects": "^1.15.0",
         "form-data": "^4.0.0",
@@ -4025,9 +4025,9 @@
       "dev": true
     },
     "axios": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.2.0.tgz",
-      "integrity": "sha512-zT7wZyNYu3N5Bu0wuZ6QccIf93Qk1eV8LOewxgjOZFd2DenOs98cJ7+Y6703d0wkaXGY6/nZd4EweJaHz9uzQw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.4.0.tgz",
+      "integrity": "sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==",
       "requires": {
         "follow-redirects": "^1.15.0",
         "form-data": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "license": "ISC",
   "dependencies": {
     "agentkeepalive": "^4.2.1",
-    "axios": "^1.1.3",
+    "axios": "^1.4.0",
     "hpagent": "^1.1.0",
     "tough-cookie": "^4.1.2"
   },


### PR DESCRIPTION
## PR Type:
Enhancement

___
## PR Description:
This PR upgrades the axios dependency from version 1.2.0 to 1.4.0. The upgrade is necessary to keep the dependencies up-to-date and to benefit from the bug fixes and improvements introduced in the newer version of axios. The upgrade affects the package.json and package-lock.json files.

___
## PR Main Files Walkthrough:
`package.json`: The axios dependency version has been updated from "^1.1.3" to "^1.4.0".
`package-lock.json`: The axios dependency version has been updated in two places from "1.2.0" to "1.4.0". The resolved URLs and integrity hashes for axios have also been updated accordingly.
